### PR TITLE
Message variable sent to wrong function in comment-added hook

### DIFF
--- a/comment-added
+++ b/comment-added
@@ -83,4 +83,4 @@ fi
 
 
 MESSAGE="$AUTHOR commented on $CHANGEURL $SCORE_BLOCK: $COMMENT"
-DoEcho "$MESSAGE"
+echo "$MESSAGE" | SendMessage


### PR DESCRIPTION
Wrong function was called in the "comment-added" hook script. It called the DoEcho function instead of SendMessage in "config.env". The comments in gerrit were not able to reach slack at all.
