### PR TITLE
Fix compatibility issues with Gerrit 2.13.

### DIFF
--- a/comment-added
+++ b/comment-added
@@ -35,18 +35,20 @@ SCORE=
 while [ $# -gt 0 ]
 do
 	case "$1" in
-		(--change)     CHANGEID="$2";  shift ;;
-		(--is-draft)   IS_DRAFT="$2";  shift ;;
-		(--change-url) CHANGEURL="$2"; shift ;;
-		(--project)    PROJECT="$2";   shift ;;
-		(--branch)     BRANCH="$2";    shift ;;
-		(--topic)      TOPIC="$2";     shift ;;
-		(--author)     AUTHOR="$2";    shift ;;
-		(--commit)     COMMIT="$2";    shift ;;
-		(--comment)    COMMENT="$2";   shift ;;
-		(--change-owner) OWNER="$2";   shift ;;
-		(--Code-Review) SCORE="$2";    shift ;;
-		(--Verified)   VERIFIED="$2";  shift ;;
+		(--change)     CHANGEID="$2";  shift;;
+		(--is-draft)   IS_DRAFT="$2";  shift;;
+		(--change-url) CHANGEURL="$2"; shift;;
+		(--project)    PROJECT="$2";   shift;;
+		(--branch)     BRANCH="$2";    shift;;
+		(--topic)      TOPIC="$2";     shift;;
+		(--author)     AUTHOR="$2";    shift;;
+		(--commit)     COMMIT="$2";    shift;;
+		(--comment)    COMMENT="$2";   shift;;
+		(--change-owner) OWNER="$2";   shift;;
+		(--Code-Review) SCORE="$2";    shift;;
+		(--Verified)   VERIFIED="$2";  shift;;
+		(--Verified-oldValue) VERIFIED_OLDVALUE="$2"; shift;;
+		(--Code-Review-oldValue) CODEREVIEW_OLDVALUE="$2"; shift;;
 		(*) DieMessage "I don't understand the option '$1'.  Exiting." ;;
 	esac
 	shift

--- a/patchset-created
+++ b/patchset-created
@@ -14,7 +14,7 @@ IS_DRAFT=
 CHANGEURL=
 PROJECT=
 BRANCH=
-TOPIC='master'
+TOPIC=
 UPLOADER=
 COMMIT=
 PATCHSET=
@@ -60,7 +60,6 @@ if [[ -z "$CHANGEID" ]] ||   \
 	[[ -z "$CHANGEURL" ]] || \
 	[[ -z "$PROJECT" ]] ||   \
 	[[ -z "$BRANCH" ]] ||    \
-	[[ -z "$TOPIC" ]] ||    \
 	[[ -z "$UPLOADER" ]] || \
 	[[ -z "$PATCHSET" ]] || \
 	[[ -z "$COMMIT" ]] ; then


### PR DESCRIPTION
I had to make these changes for the hooks to work on Gerrit >= 2.13

Mostly just a couple of new flags that are passed that the script didn't expect, and the topic no longer being set by default (the `--topic` flag is passed but an empty string value is given to it by default).
